### PR TITLE
ProcessNameEnricher and customization of the property name

### DIFF
--- a/src/Serilog.Enrichers.Process/Enrichers/ProcessNameEnricher.cs
+++ b/src/Serilog.Enrichers.Process/Enrichers/ProcessNameEnricher.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2013-2015 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+ 
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Serilog.Enrichers
+{
+    /// <summary>
+    /// Enriches log events with a ProcessName property containing the current <see cref="System.Diagnostics.Process.ProcessName"/>.
+    /// </summary>
+    public class ProcessNameEnricher : ILogEventEnricher
+    {
+        LogEventProperty _cachedProperty;
+
+        /// <summary>
+        /// The property name added to enriched log events.
+        /// </summary>
+        public const string ProcessNamePropertyName = "ProcessName";
+
+        /// <summary>
+        /// Enrich the log event.
+        /// </summary>
+        /// <param name="logEvent">The log event to enrich.</param>
+        /// <param name="propertyFactory">Factory for creating new properties to add to the event.</param>
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            _cachedProperty = _cachedProperty ?? propertyFactory.CreateProperty(ProcessNamePropertyName, System.Diagnostics.Process.GetCurrentProcess().ProcessName);
+            logEvent.AddPropertyIfAbsent(_cachedProperty);
+        }
+    }   
+}

--- a/src/Serilog.Enrichers.Process/ProcessLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Enrichers.Process/ProcessLoggerConfigurationExtensions.cs
@@ -24,9 +24,9 @@ namespace Serilog
     /// capabilities.
     /// </summary>
     public static class ProcessLoggerConfigurationExtensions
-    { 
+    {
         /// <summary>
-        /// Enrich log events with a ProcessId property containing the current <see cref="Process.Id"/>.
+        /// Enrich log events with a ProcessId property containing the current <see cref="System.Diagnostics.Process.Id"/>.
         /// </summary>
         /// <param name="enrichmentConfiguration">Logger enrichment configuration.</param>
         /// <returns>Configuration object allowing method chaining.</returns>
@@ -35,6 +35,18 @@ namespace Serilog
         {
             if (enrichmentConfiguration == null) throw new ArgumentNullException(nameof(enrichmentConfiguration));
             return enrichmentConfiguration.With<ProcessIdEnricher>();
-        } 
+        }
+
+        /// <summary>
+        /// Enrich log events with a ProcessName property containing the current <see cref="System.Diagnostics.Process.ProcessName"/>.
+        /// </summary>
+        /// <param name="enrichmentConfiguration">Logger enrichment configuration.</param>
+        /// <returns>Configuration object allowing method chaining.</returns>
+        public static LoggerConfiguration WithProcessName(
+           this LoggerEnrichmentConfiguration enrichmentConfiguration)
+        {
+            if (enrichmentConfiguration == null) throw new ArgumentNullException(nameof(enrichmentConfiguration));
+            return enrichmentConfiguration.With<ProcessNameEnricher>();
+        }
     }
 }


### PR DESCRIPTION
Hi guys!

Here are two changes:

1. ProcessNameEnricher. It allows to enrich log event with name of the process.
2. Customization of the property names. Due to transition from log4net to serilog we have some legacy stuff when the name of the process is stored not in the "ProcessName" property, but in the "Facility" property, so we need an ability to override it.