### PR TITLE
Update the appveyor script to not use the 1.0.0-preview2 SDK

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,7 @@
 version: '{build}'
 skip_tags: true
-image: Visual Studio 2015
+image: Visual Studio 2017
 configuration: Release
-install:
-  - ps: mkdir -Force ".\build\" | Out-Null
-  - ps: Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0-preview2/scripts/obtain/dotnet-install.ps1" -OutFile ".\build\installcli.ps1"
-  - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetcli"
-  - ps: '& .\build\installcli.ps1 -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath -Version 1.0.0-preview2-003121'
-  - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
 build_script:
 - ps: ./Build.ps1
 test: off

--- a/global.json
+++ b/global.json
@@ -1,6 +1,3 @@
 {
-  "projects": [ "src", "test" ],
-  "sdk": {
-    "version": "1.0.0-preview2-003121"
-  }
+  "projects": [ "src", "test" ]
 }


### PR DESCRIPTION
Note: I know very little about Appveyor scripts, the change is just copying what the thread enricher build does.