### PR TITLE
Enable SourceLink in the build/nuget package

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -23,7 +23,7 @@ foreach ($src in ls src/*) {
 
 	echo "build: Packaging project in $src"
 
-    & dotnet build -c Release --version-suffix=$buildSuffix
+    & dotnet build -c Release --version-suffix=$buildSuffix /p:ContinuousIntegrationBuild=true
     & dotnet pack -c Release -o ..\..\artifacts --version-suffix=$suffix --no-build
     if($LASTEXITCODE -ne 0) { exit 1 }    
 

--- a/src/Serilog.Enrichers.Process/Serilog.Enrichers.Process.csproj
+++ b/src/Serilog.Enrichers.Process/Serilog.Enrichers.Process.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>The process enricher for Serilog.</Description>
@@ -15,9 +15,18 @@
     <PackageProjectUrl>http://serilog.net</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <RepositoryUrl>https://github.com/serilog/serilog-enrichers-process</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Serilog" Version="2.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
-Add the ```Microsoft.SourceLink.GitHub``` package to the build
-Add the repository properties to the project
-Enable ```ContinuousIntegrationBuild``` in the CI build

It's set to embed the pdb in the package - I don't know if that's right, or if it should be using a symbol package? (the other Serilog projects look a bit mixed in that area?)