### PR TITLE
Add a netstandard2.0 target to the build

### DIFF
--- a/src/Serilog.Enrichers.Process/Serilog.Enrichers.Process.csproj
+++ b/src/Serilog.Enrichers.Process/Serilog.Enrichers.Process.csproj
@@ -4,7 +4,7 @@
     <Description>The process enricher for Serilog.</Description>
     <VersionPrefix>2.0.2</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
-    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.3;netstandard2.0</TargetFrameworks>
     <AssemblyName>Serilog.Enrichers.Process</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
Add a netstandard2.0 target on top of the existing net45 and netstandard1.3 targets.
The 2.0 target doesn't need the ```System.Diagnostics.Process``` PackageReference so it simplifies the dependencies a little.

I don't know if there would be any benefit in adding a netstandard2.1 target at this point?