### PR TITLE
Use System.Environment.ProcessId where available

### DIFF
--- a/src/Serilog.Enrichers.Process/Enrichers/ProcessIdEnricher.cs
+++ b/src/Serilog.Enrichers.Process/Enrichers/ProcessIdEnricher.cs
@@ -42,10 +42,14 @@ namespace Serilog.Enrichers
 
         private static int GetProcessId()
         {
-            using(var process = System.Diagnostics.Process.GetCurrentProcess())
+#if FEATURE_ENVIRONMENT_PID
+            return System.Environment.ProcessId;
+#else
+            using (var process = System.Diagnostics.Process.GetCurrentProcess())
             {
                 return process.Id;
             }
+#endif
         }
     }
 }

--- a/src/Serilog.Enrichers.Process/Serilog.Enrichers.Process.csproj
+++ b/src/Serilog.Enrichers.Process/Serilog.Enrichers.Process.csproj
@@ -39,6 +39,10 @@
     <PackageReference Include="System.Diagnostics.Process" Version="4.1.0" />
   </ItemGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <DefineConstants>$(DefineConstants);FEATURE_ENVIRONMENT_PID</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="..\..\assets\serilog-enricher-nuget.png">
       <Pack>True</Pack>


### PR DESCRIPTION
A followup to the suggestion in #17 to use System.Environment.ProcessId instead of GetCurrentProcess().Id on .NET5+.

I believe that ```NET``` is the built in define for .NET 5.0+ (So it'll remain defined on 6+ as well) , but that could be made some thing more explicit if needed