### PR TITLE
Update the SourceLink NuGet package

### DIFF
--- a/src/Serilog.Enrichers.Process/Serilog.Enrichers.Process.csproj
+++ b/src/Serilog.Enrichers.Process/Serilog.Enrichers.Process.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Although saying that, maybe we could update the build to use the .NET 8 SDK next week and then try just using the inbox SourceLink bits